### PR TITLE
添加 destScale 属性

### DIFF
--- a/components/painter/painter.js
+++ b/components/painter/painter.js
@@ -18,6 +18,10 @@ Component({
     customStyle: {
       type: String,
     },
+    destScale: {
+      type: Number,
+      value: 1,
+    },
     palette: {
       type: Object,
       observer: function (newVal, oldVal) {
@@ -155,9 +159,12 @@ Component({
 
     saveImgToLocal() {
       const that = this;
+      const scale = that.data.destScale
       setTimeout(() => {
         wx.canvasToTempFilePath({
           canvasId: 'k-canvas',
+          destWidth: that.canvasWidthInPx * scale,
+          destHeight: that.canvasHeightInPx * scale,
           success: function (res) {
             that.getImageInfo(res.tempFilePath);
           },


### PR DESCRIPTION
组件目前的图片输出在有些情况下会导致图片模糊问题。wx.canvasToTempFilePath 提供 destWidth 和 destHeight 参数，添加 destScale 属性可生成高质量的大图。