### PR TITLE
对 background: transparent 值做特殊处理，以支持透明背景

### DIFF
--- a/components/painter/lib/pen.js
+++ b/components/painter/lib/pen.js
@@ -34,7 +34,7 @@ export default class Painter {
       // 如果未设置背景，则默认使用白色
       this.ctx.setFillStyle('#fff');
       this.ctx.fillRect(-(width / 2), -(height / 2), width, height);
-    } else if (bg.startsWith('#') || bg.startsWith('rgba')) {
+    } else if (bg.startsWith('#') || bg.startsWith('rgba') || bg.toLowerCase() === 'transparent') {
       // 背景填充颜色
       this.ctx.setFillStyle(bg);
       this.ctx.fillRect(-(width / 2), -(height / 2), width, height);


### PR DESCRIPTION
修复指定 transparent 属性值会当做本地图片处理以至于出现 VM22878:2 Failed to load local image resource 的错误，已在背景填充颜色逻辑上对 transparent 做了特殊判断处理