### PR TITLE
完善绘制image的 aspectFill 模式

### DIFF
--- a/components/painter/lib/pen.js
+++ b/components/painter/lib/pen.js
@@ -226,22 +226,20 @@ export default class Painter {
       height,
     } = this._preProcess(view);
     // 获得缩放到图片大小级别的裁减框
-    let rWidth;
-    let rHeight;
+    let rWidth = view.sWidth;
+    let rHeight = view.sHeight;
     let startX = 0;
     let startY = 0;
-    if (view.sHeight > view.sWidth) {
-      rHeight = Math.round((view.sWidth / width) * height);
-      rWidth = view.sWidth;
-    } else {
-      rWidth = Math.round((view.sHeight / height) * width);
-      rHeight = view.sHeight;
-    }
-    if (view.sWidth > rWidth) {
-      startX = Math.round((view.sWidth - rWidth) / 2);
-    }
-    if (view.sHeight > rHeight) {
+    // 绘画区域比例
+    const cp = width / height;
+    // 原图比例
+    const op = view.sWidth / view.sHeight;
+    if (cp >= op) {
+      rHeight = rWidth / cp;
       startY = Math.round((view.sHeight - rHeight) / 2);
+    } else {
+      rWidth = rHeight * cp;
+      startX = Math.round((view.sWidth - rWidth) / 2);
     }
     if (view.css && view.css.mode === 'scaleToFill') {
       this.ctx.drawImage(view.url, -(width / 2), -(height / 2), width, height);


### PR DESCRIPTION
完善aspectFill这个模式，保持纵横比缩放图片，只保证图片的短边能完全显示出来。也就是说，图片通常只在水平或垂直方向是完整的，另一个方向将会发生截取。

### **修改前**
![image](https://user-images.githubusercontent.com/17608015/49275555-907aeb00-f4b6-11e8-81b5-39d140c721e4.png)

### **修改后**
![image](https://user-images.githubusercontent.com/17608015/49279214-d1c4c800-f4c1-11e8-815c-7191b87e7eeb.png)

