### PR TITLE
[Mod] 绘制文字时有bg和borderRadius时圆角在bg上并且文字不圆角

### DIFF
--- a/components/painter/lib/pen.js
+++ b/components/painter/lib/pen.js
@@ -250,13 +250,14 @@ export default class Painter {
     }
     const width = rawWidth + pd[1] + pd[3];
     const height = rawHeight + pd[0] + pd[2];
+    this._doClip(view.css.borderRadius, width, height)
     if (GD.api.isGradient(background)) {
       GD.api.doGradient(background, width, height, this.ctx);
     } else {
       this.ctx.setFillStyle(background);
     }
     this.ctx.fillRect(-(width / 2), -(height / 2), width, height);
-
+    
     this.ctx.restore();
   }
 
@@ -318,7 +319,7 @@ export default class Painter {
       width,
       height,
       extra,
-    } = this._preProcess(view);
+    } = this._preProcess(view, view.css.background && view.css.borderRadius);
 
     this.ctx.setFillStyle(view.css.color || 'black');
     const {


### PR DESCRIPTION
<img width="84" alt="WX20190513-094912@2x" src="https://user-images.githubusercontent.com/17824466/57592308-95b18b00-7568-11e9-8a95-396f0d81fd7e.png">
将上图展示情况修改为下图展示情况
<img width="84" alt="WX20190513-094413@2x" src="https://user-images.githubusercontent.com/17824466/57592317-a235e380-7568-11e9-9cde-2e86bdf88495.png">
