### PR TITLE
生成带logo的二维码

### DIFF
--- a/components/painter/lib/pen.js
+++ b/components/painter/lib/pen.js
@@ -325,6 +325,10 @@ export default class Painter {
       height,
     } = this._preProcess(view);
     QR.api.draw(view.content, this.ctx, -width / 2, -height / 2, width, height, view.css.background, view.css.color);
+    /* 生成带logo 二维码*/
+    if (view.logo) {
+      this.ctx.drawImage(view.logo, -(width / 6), -(height / 6), width / 3, height / 3);
+    }
     this.ctx.restore();
     this._doBorder(view, width, height);
   }

--- a/palette/card.js
+++ b/palette/card.js
@@ -85,6 +85,7 @@ export default class LastMayday {
         {
           type: 'qrcode',
           content: 'https://github.com/Kujiale-Mobile/Painter',
+          logo: '/palette/avatar.jpg',
           css: {
             bottom: '40rpx',
             left: '180rpx',


### PR DESCRIPTION
我们生成二维码时，需要带上公司的logo，希望可以支持。不然还需要单独绘制一张图片贴在二维码上面，控制位置，比较繁琐。