### PR TITLE
fix: downloader bug when image size > MAX_SPACE_IN_B

### DIFF
--- a/components/painter/lib/downloader.js
+++ b/components/painter/lib/downloader.js
@@ -155,6 +155,9 @@ function reset() {
 }
 
 function doLru(size) {
+  if (size > MAX_SPACE_IN_B) {
+    return Promise.reject()
+  }
   return new Promise((resolve, reject) => {
     let totalSize = savedFiles[KEY_TOTAL_SIZE] ? savedFiles[KEY_TOTAL_SIZE] : 0;
 


### PR DESCRIPTION
当下载单张网络图片大小已经大于 MAX_SPACE_IN_B 时，不应该再走 LRU 流程