### PR TITLE
fix:视图view未指定css时报错

### DIFF
--- a/components/painter/lib/pen.js
+++ b/components/painter/lib/pen.js
@@ -409,7 +409,7 @@ export default class Painter {
   _doPaddings(view) {
     const {
       padding,
-    } = view.css;
+    } = view.css ? view.css : {};
     let pd = [0, 0, 0, 0];
     if (padding) {
       const pdg = padding.split(/\s+/);


### PR DESCRIPTION
Palette JSON模版中未指定`css`，就会报错。如下图。

<img width="426" alt="QQ20200830-153839@2x" src="https://user-images.githubusercontent.com/3274949/91654183-687c4980-ead9-11ea-8874-3bbb79a5bcec.png">
<img width="828" alt="QQ20200830-153826@2x" src="https://user-images.githubusercontent.com/3274949/91654188-6b773a00-ead9-11ea-9988-7aabc6fadfc8.png">
<img width="942" alt="QQ20200830-153752@2x" src="https://user-images.githubusercontent.com/3274949/91654190-6c0fd080-ead9-11ea-84d4-cc256c4499f5.png">
