### PR TITLE
fix: 传给 `view.text` 的动态数据非字符串时报错

### DIFF
--- a/components/painter/lib/pen.js
+++ b/components/painter/lib/pen.js
@@ -204,7 +204,7 @@ export default class Painter {
     const paddings = this._doPaddings(view);
     switch (view.type) {
       case 'text': {
-        const textArray = view.text.split('\n');
+        const textArray = String(view.text).split('\n');
         // 处理多个连续的'\n'
         for (let i = 0; i < textArray.length; ++i) {
           if (textArray[i] === '') {


### PR DESCRIPTION
有时候，传给 `view.text` 的数据是动态的，可能是数字而非字符串（这里的 `options.total` 是一个数字）：

![222](https://user-images.githubusercontent.com/43442630/98501671-dcca2a80-228a-11eb-97a6-9827c04dde5c.png)

此时就会报错，如下图：

![Snipaste_2020-11-09_11-08-05](https://user-images.githubusercontent.com/43442630/98501552-8230ce80-228a-11eb-9964-afbc75f3c2ba.png)

虽然文档有提到 `text` 需要接受一个 `String` 类型的值，但动态传值有时候会忘记将数字转化为字符串，所以建议在 `pen.js` 的 `__preProcess` 函数中对 `view.text` 直接做字符串转化的处理。
