### PR TITLE
fix: 2d 接口渲染模糊，且 IOS 中显示不全

### DIFF
--- a/components/painter/lib/wx-canvas.js
+++ b/components/painter/lib/wx-canvas.js
@@ -17,7 +17,11 @@ export default class WxCanvas {
   }
 
   set width(w) {
-    if (this.canvasNode) this.canvasNode.width = w;
+    if (this.canvasNode) {
+      this.canvasNode.width = w;
+      // 经测试，在 2d 接口中如果不设置这个值，IOS 端有一定几率会出现图片显示不全的情况。
+      this.canvasNode._width = w;
+    }
   }
 
   get width() {
@@ -26,7 +30,11 @@ export default class WxCanvas {
   }
 
   set height(h) {
-    if (this.canvasNode) this.canvasNode.height = h;
+    if (this.canvasNode) {
+      this.canvasNode.height = h;
+      // 经测试，在 2d 接口中如果不设置这个值，IOS 端有一定几率会出现图片显示不全的情况。
+      this.canvasNode._height = h;
+    }
   }
 
   get height() {

--- a/components/painter/painter.js
+++ b/components/painter/painter.js
@@ -734,13 +734,18 @@ Component({
 
     saveImgToLocal() {
       const that = this;
+      const optionsOf2d = {
+        canvas: that.canvasNode,
+      }
+      const optionsOfOld = {
+        canvasId: 'photo',
+        destWidth: that.canvasWidthInPx,
+        destHeight: that.canvasHeightInPx,
+      }
       setTimeout(() => {
         wx.canvasToTempFilePath(
           {
-            canvasId: 'photo',
-            canvas: that.properties.use2D ? that.canvasNode : null,
-            destWidth: that.canvasWidthInPx,
-            destHeight: that.canvasHeightInPx,
+            ...(that.properties.use2D ? optionsOf2d : optionsOfOld),
             success: function (res) {
               that.getImageInfo(res.tempFilePath);
             },


### PR DESCRIPTION
问题：在使用 canvas 2d 接口时，渲染出来的图片显示模糊，且在 IOS 中渲染出来的图片有一定几率显示不全。

问题复现请参照该代码片段：https://developers.weixin.qq.com/s/84m447m47rxT